### PR TITLE
Features/add-block-babylonjs-viewer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
+/build
 /package-lock.json

--- a/README.md
+++ b/README.md
@@ -36,4 +36,14 @@ npm install
 npm run wp-env start
 ```
 
+3. Watch `src/` directory and block files
+```sh
+npm run start
+```
+
+4. Build `src/` directory and block files for **production**
+```sh
+npm run build
+```
+
 ---

--- a/babylonjs-viewer.php
+++ b/babylonjs-viewer.php
@@ -10,3 +10,9 @@
  * Requires at least:   5.9
  * Requires PHP:        7.4
  */
+
+add_action('init', function() {
+    register_block_type(
+        plugin_dir_path(__FILE__) . 'build/babylonjs-viewer'
+    );
+});

--- a/package.json
+++ b/package.json
@@ -3,9 +3,12 @@
   "version": "0.1.0",
   "scripts": {
     "wp-env": "wp-env",
+    "start": "wp-scripts start",
+    "build": "wp-scripts build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
-    "@wordpress/env": "^5.9.0"
+    "@wordpress/env": "^5.9.0",
+    "@wordpress/scripts": "^25.1.0"
   }
 }

--- a/src/babylonjs-viewer/block.json
+++ b/src/babylonjs-viewer/block.json
@@ -1,0 +1,17 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "create-block/babylonjs-viewer",
+	"version": "0.1.0",
+	"title": "Babylon.JS Viewer",
+	"category": "widgets",
+	"icon": "smiley",
+	"description": "Load 3D models using Babylon.JS Viewer.",
+	"supports": {
+		"html": false
+	},
+	"textdomain": "babylonjs-viewer",
+	"editorScript": "file:./index.js",
+	"editorStyle": "file:./index.css",
+	"style": "file:./style-index.css"
+}

--- a/src/babylonjs-viewer/edit.js
+++ b/src/babylonjs-viewer/edit.js
@@ -1,0 +1,12 @@
+import { __ } from '@wordpress/i18n';
+import { useBlockProps } from '@wordpress/block-editor';
+
+import './editor.scss';
+
+export default function edit() {
+	return (
+		<p { ...useBlockProps() }>
+			{ __( 'Babylon.JS Viewer – hello from the editor!', 'babylonjs-viewer' ) }
+		</p>
+	);
+}

--- a/src/babylonjs-viewer/editor.scss
+++ b/src/babylonjs-viewer/editor.scss
@@ -1,0 +1,3 @@
+.wp-block-create-block-babylonjs-viewer {
+	border: 1px dotted #f00;
+}

--- a/src/babylonjs-viewer/index.js
+++ b/src/babylonjs-viewer/index.js
@@ -1,0 +1,12 @@
+import { registerBlockType } from '@wordpress/blocks';
+
+import './style.scss';
+
+import edit from './edit';
+import save from './save';
+import metadata from './block.json';
+
+registerBlockType( metadata.name, {
+	edit,
+	save,
+} );

--- a/src/babylonjs-viewer/save.js
+++ b/src/babylonjs-viewer/save.js
@@ -1,0 +1,9 @@
+import { useBlockProps } from '@wordpress/block-editor';
+
+export default function save() {
+	return (
+		<p { ...useBlockProps.save() }>
+			{ 'Babylon.JS Viewer – hello from the saved content!' }
+		</p>
+	);
+}

--- a/src/babylonjs-viewer/style.scss
+++ b/src/babylonjs-viewer/style.scss
@@ -1,0 +1,5 @@
+.wp-block-create-block-babylonjs-viewer {
+	background-color: #21759b;
+	color: #fff;
+	padding: 2px;
+}


### PR DESCRIPTION
Setup assets for block development and generate block files with `@wordpress/create-block`.