### PR TITLE
Features/block-babylonjs-viewer-add-url-field

### DIFF
--- a/babylonjs-viewer.php
+++ b/babylonjs-viewer.php
@@ -15,4 +15,12 @@ add_action('init', function() {
     register_block_type(
         plugin_dir_path(__FILE__) . 'build/babylonjs-viewer'
     );
+
+    wp_register_script(
+        'babylonjs-viewer',
+        'https://cdn.babylonjs.com/viewer/babylon.viewer.js',
+        [],
+        null,
+        true
+    );
 });

--- a/package.json
+++ b/package.json
@@ -10,5 +10,8 @@
   "devDependencies": {
     "@wordpress/env": "^5.9.0",
     "@wordpress/scripts": "^25.1.0"
+  },
+  "dependencies": {
+    "@wordpress/components": "^23.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@wordpress/scripts": "^25.1.0"
   },
   "dependencies": {
-    "@wordpress/components": "^23.1.0"
+    "@wordpress/components": "^23.1.0",
+    "@wordpress/element": "^5.1.0"
   }
 }

--- a/src/babylonjs-viewer/block.json
+++ b/src/babylonjs-viewer/block.json
@@ -18,5 +18,6 @@
 	"textdomain": "babylonjs-viewer",
 	"editorScript": "file:./index.js",
 	"editorStyle": "file:./index.css",
-	"style": "file:./style-index.css"
+	"style": "file:./style-index.css",
+	"viewScript": "babylonjs-viewer"
 }

--- a/src/babylonjs-viewer/block.json
+++ b/src/babylonjs-viewer/block.json
@@ -10,6 +10,11 @@
 	"supports": {
 		"html": false
 	},
+	"attributes": {
+		"url": {
+			"type": "string"
+		}
+	},
 	"textdomain": "babylonjs-viewer",
 	"editorScript": "file:./index.js",
 	"editorStyle": "file:./index.css",

--- a/src/babylonjs-viewer/edit.js
+++ b/src/babylonjs-viewer/edit.js
@@ -1,12 +1,23 @@
 import { __ } from '@wordpress/i18n';
 import { useBlockProps } from '@wordpress/block-editor';
+import { TextControl } from '@wordpress/components';
 
 import './editor.scss';
 
-export default function edit() {
+export default function edit({ attributes, setAttributes }) {
+	const { url } = attributes;
+
 	return (
-		<p { ...useBlockProps() }>
-			{ __( 'Babylon.JS Viewer – hello from the editor!', 'babylonjs-viewer' ) }
-		</p>
+		<div { ...useBlockProps() }>
+			<TextControl
+				label="Model URL"
+				value={url}
+				onChange={(newValue) => {
+					setAttributes({
+						url: newValue,
+					});
+				}}
+			/>
+		</div>
 	);
 }

--- a/src/babylonjs-viewer/save.js
+++ b/src/babylonjs-viewer/save.js
@@ -1,9 +1,24 @@
-import { useBlockProps } from '@wordpress/block-editor';
+import { useBlockProps } from "@wordpress/block-editor";
+import { Fragment } from "@wordpress/element";
 
-export default function save() {
+export default function save({ attributes }) {
+	const { url } = attributes;
+
 	return (
-		<p { ...useBlockProps.save() }>
-			{ 'Babylon.JS Viewer – hello from the saved content!' }
-		</p>
+		<div { ...useBlockProps.save() }>
+			{(url && url !== "") &&
+				<Fragment>
+					<p>
+						{ `Loading model from "${url}"`}
+					</p>
+					<babylon model={url}></babylon>
+				</Fragment>
+			}
+			{!url &&
+				<p>
+					{ "No URL selected" }
+				</p>
+			}
+		</div>
 	);
 }


### PR DESCRIPTION
Added `url` field to **Babylon.JS Viewer** block and create basic frontend view.

---
- Added `@wordpress/components` and `@wordpress/element` for block development
- Added `url` field to **Babylon.JS Viewer** block
- Added `babylonjs-viewer` external script to render models
- Added block initial frontend view with fallback