### PR TITLE
Features/remove-cross-site-warnings

### DIFF
--- a/babylonjs-viewer.php
+++ b/babylonjs-viewer.php
@@ -15,12 +15,4 @@ add_action('init', function() {
     register_block_type(
         plugin_dir_path(__FILE__) . 'build/babylonjs-viewer'
     );
-
-    wp_register_script(
-        'babylonjs-viewer',
-        'https://cdn.babylonjs.com/viewer/babylon.viewer.js',
-        [],
-        null,
-        true
-    );
 });

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@wordpress/components": "^23.1.0",
-    "@wordpress/element": "^5.1.0"
+    "@wordpress/element": "^5.1.0",
+    "babylonjs-viewer": "^5.42.2"
   }
 }

--- a/src/babylonjs-viewer/block.json
+++ b/src/babylonjs-viewer/block.json
@@ -19,5 +19,5 @@
 	"editorScript": "file:./index.js",
 	"editorStyle": "file:./index.css",
 	"style": "file:./style-index.css",
-	"viewScript": "babylonjs-viewer"
+	"viewScript": "file:./view.js"
 }

--- a/src/babylonjs-viewer/view.js
+++ b/src/babylonjs-viewer/view.js
@@ -1,0 +1,1 @@
+import "babylonjs-viewer";


### PR DESCRIPTION
Replaced `babylonjs-viewer` script source to avoid external / cross-site access warnings

- removed CDN use for `babylonjs-viewer`
- add `babylonjs-viewer` as dependencies