### PR TITLE
Features/allow-model-from-media-library

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,7 +1,7 @@
 {
-    "core": "WordPress/WordPress#6.1.1",
-    "phpVersion": "7.4",
-    "plugins": [
-        "."
-    ]
+  "core": "WordPress/WordPress#6.1.1",
+  "phpVersion": "7.4",
+  "plugins": [
+    "."
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Allow users to view and add 3D models to their content with Babylon.js Viewer.
 
 3. Add **Babylon.js Viewer** block to a page.
 
-4. Add the model **URL** to the block.
+4. Add the model **URL** to the block or select a model from the **Media Library**.
 
 Model example:
 https://playground.babylonjs.com/scenes/BoomBox/BoomBox.gltf

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ https://playground.babylonjs.com/scenes/BoomBox/BoomBox.gltf
 
 Video Tutorial:
 
-https://user-images.githubusercontent.com/57893611/212638558-d07e3a5d-2d9d-4524-9ddd-6d171bc3a54b.mov
+https://user-images.githubusercontent.com/57893611/212997321-70a30088-a1bd-4f7f-aa6c-1f396253ea06.mov
 
 
 ---

--- a/src/babylonjs-viewer/block.json
+++ b/src/babylonjs-viewer/block.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
-	"name": "create-block/babylonjs-viewer",
+	"name": "babylonjs-viewer/babylonjs-viewer",
 	"version": "0.1.0",
 	"title": "Babylon.JS Viewer",
 	"category": "widgets",

--- a/src/babylonjs-viewer/block.json
+++ b/src/babylonjs-viewer/block.json
@@ -1,27 +1,27 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
-	"name": "babylonjs-viewer/babylonjs-viewer",
-	"version": "0.1.0",
-	"title": "Babylon.JS Viewer",
-	"category": "widgets",
-	"icon": "smiley",
-	"description": "Load 3D models using Babylon.JS Viewer.",
-	"supports": {
-		"html": false
-	},
-	"attributes": {
-		"model": {
-			"type": "object",
-			"default": {
-				"title": "",
-				"url": ""
-			}
-		}
-	},
-	"textdomain": "babylonjs-viewer",
-	"editorScript": "file:./index.js",
-	"editorStyle": "file:./index.css",
-	"style": "file:./style-index.css",
-	"viewScript": "file:./view.js"
+  "$schema": "https://schemas.wp.org/trunk/block.json",
+  "apiVersion": 2,
+  "name": "babylonjs-viewer/babylonjs-viewer",
+  "version": "0.1.0",
+  "title": "Babylon.JS Viewer",
+  "category": "widgets",
+  "icon": "smiley",
+  "description": "Load 3D models using Babylon.JS Viewer.",
+  "supports": {
+    "html": false
+  },
+  "attributes": {
+    "model": {
+      "type": "object",
+      "default": {
+        "title": "",
+        "url": ""
+      }
+    }
+  },
+  "textdomain": "babylonjs-viewer",
+  "editorScript": "file:./index.js",
+  "editorStyle": "file:./index.css",
+  "style": "file:./style-index.css",
+  "viewScript": "file:./view.js"
 }

--- a/src/babylonjs-viewer/block.json
+++ b/src/babylonjs-viewer/block.json
@@ -11,8 +11,12 @@
 		"html": false
 	},
 	"attributes": {
-		"url": {
-			"type": "string"
+		"model": {
+			"type": "object",
+			"default": {
+				"title": "",
+				"url": ""
+			}
 		}
 	},
 	"textdomain": "babylonjs-viewer",

--- a/src/babylonjs-viewer/edit.js
+++ b/src/babylonjs-viewer/edit.js
@@ -6,68 +6,68 @@ import { Fragment } from "@wordpress/element"
 import "./editor.scss";
 
 export default function edit({ attributes, setAttributes }) {
-	const { model } = attributes;
-	const { title, url } = model;
+  const { model } = attributes;
+  const { title, url } = model;
 
-	return (
-		<div { ...useBlockProps() }>
-			<Fragment>
-				<p>
-					{`Enter the model metas or `}
-					<MediaUpload
-						onSelect={({ title, url }) => {
-							setAttributes({
-								model: {
-									title: title,
-									url: url,
-								},
-							});
-						}}
-						multiple={false}
-						render={({ open }) => (
-							<Fragment>
-								<Button
-									onClick={open}
-									variant="link"
-									style={{
-										color: "white",
-										padding: 0,
-										fontSize: "inherit",
-									}}
-								>
-									select from Media Library
-								</Button>
-							</Fragment>
-						)}
-					/>
-				</p>
-			</Fragment>
-			<Fragment>
-				<TextControl
-					label="Title"
-					value={title}
-					onChange={(newValue) => {
-						setAttributes({
-							model: {
-								title: newValue,
-								url: url,
-							},
-						});
-					}}
-				/>
-				<TextControl
-					label="URL"
-					value={url}
-					onChange={(newValue) => {
-						setAttributes({
-							model: {
-								title: title,
-								url: newValue,
-							}
-						});
-					}}
-				/>
-			</Fragment>
-		</div>
-	);
+  return (
+    <div { ...useBlockProps() }>
+      <Fragment>
+        <p>
+          {`Enter the model metas or `}
+          <MediaUpload
+            onSelect={({ title, url }) => {
+              setAttributes({
+                model: {
+                  title: title,
+                  url: url,
+                },
+              });
+            }}
+            multiple={false}
+            render={({ open }) => (
+              <Fragment>
+                <Button
+                  onClick={open}
+                  variant="link"
+                  style={{
+                    color: "white",
+                    padding: 0,
+                    fontSize: "inherit",
+                  }}
+                >
+                  select from Media Library
+                </Button>
+              </Fragment>
+            )}
+          />
+        </p>
+      </Fragment>
+      <Fragment>
+        <TextControl
+          label="Title"
+          value={title}
+          onChange={(newValue) => {
+            setAttributes({
+              model: {
+                title: newValue,
+                url: url,
+              },
+            });
+          }}
+        />
+        <TextControl
+          label="URL"
+          value={url}
+          onChange={(newValue) => {
+            setAttributes({
+              model: {
+                title: title,
+                url: newValue,
+              }
+            });
+          }}
+        />
+      </Fragment>
+    </div>
+  );
 }

--- a/src/babylonjs-viewer/edit.js
+++ b/src/babylonjs-viewer/edit.js
@@ -1,8 +1,9 @@
-import { __ } from '@wordpress/i18n';
-import { useBlockProps } from '@wordpress/block-editor';
-import { TextControl } from '@wordpress/components';
+import { __ } from "@wordpress/i18n";
+import { useBlockProps, MediaUpload } from "@wordpress/block-editor";
+import { TextControl, Button } from "@wordpress/components";
+import { Fragment } from "@wordpress/element"
 
-import './editor.scss';
+import "./editor.scss";
 
 export default function edit({ attributes, setAttributes }) {
 	const { model } = attributes;
@@ -10,30 +11,63 @@ export default function edit({ attributes, setAttributes }) {
 
 	return (
 		<div { ...useBlockProps() }>
-			<TextControl
-				label="Title"
-				value={title}
-				onChange={(newValue) => {
-					setAttributes({
-						model: {
-							title: newValue,
-							url: url,
-						},
-					});
-				}}
-			/>
-			<TextControl
-				label="URL"
-				value={url}
-				onChange={(newValue) => {
-					setAttributes({
-						model: {
-							title: title,
-							url: newValue,
-						}
-					});
-				}}
-			/>
+			<Fragment>
+				<p>
+					{`Enter the model metas or `}
+					<MediaUpload
+						onSelect={({ title, url }) => {
+							setAttributes({
+								model: {
+									title: title,
+									url: url,
+								},
+							});
+						}}
+						multiple={false}
+						render={({ open }) => (
+							<Fragment>
+								<Button
+									onClick={open}
+									variant="link"
+									style={{
+										color: "white",
+										padding: 0,
+										fontSize: "inherit",
+									}}
+								>
+									select from Media Library
+								</Button>
+							</Fragment>
+						)}
+					/>
+				</p>
+			</Fragment>
+			<Fragment>
+				<TextControl
+					label="Title"
+					value={title}
+					onChange={(newValue) => {
+						setAttributes({
+							model: {
+								title: newValue,
+								url: url,
+							},
+						});
+					}}
+				/>
+				<TextControl
+					label="URL"
+					value={url}
+					onChange={(newValue) => {
+						setAttributes({
+							model: {
+								title: title,
+								url: newValue,
+							}
+						});
+					}}
+				/>
+			</Fragment>
 		</div>
 	);
 }

--- a/src/babylonjs-viewer/edit.js
+++ b/src/babylonjs-viewer/edit.js
@@ -5,16 +5,32 @@ import { TextControl } from '@wordpress/components';
 import './editor.scss';
 
 export default function edit({ attributes, setAttributes }) {
-	const { url } = attributes;
+	const { model } = attributes;
+	const { title, url } = model;
 
 	return (
 		<div { ...useBlockProps() }>
 			<TextControl
-				label="Model URL"
+				label="Title"
+				value={title}
+				onChange={(newValue) => {
+					setAttributes({
+						model: {
+							title: newValue,
+							url: url,
+						},
+					});
+				}}
+			/>
+			<TextControl
+				label="URL"
 				value={url}
 				onChange={(newValue) => {
 					setAttributes({
-						url: newValue,
+						model: {
+							title: title,
+							url: newValue,
+						}
 					});
 				}}
 			/>

--- a/src/babylonjs-viewer/editor.scss
+++ b/src/babylonjs-viewer/editor.scss
@@ -1,3 +1,3 @@
 .wp-block-babylonjs-viewer-babylonjs-viewer {
-	border: 1px dotted #f00;
+  border: 1px dotted #f00;
 }

--- a/src/babylonjs-viewer/editor.scss
+++ b/src/babylonjs-viewer/editor.scss
@@ -1,3 +1,3 @@
-.wp-block-create-block-babylonjs-viewer {
+.wp-block-babylonjs-viewer-babylonjs-viewer {
 	border: 1px dotted #f00;
 }

--- a/src/babylonjs-viewer/index.js
+++ b/src/babylonjs-viewer/index.js
@@ -6,7 +6,7 @@ import edit from './edit';
 import save from './save';
 import metadata from './block.json';
 
-registerBlockType( metadata.name, {
-	edit,
-	save,
-} );
+registerBlockType(metadata.name, {
+  edit,
+  save,
+});

--- a/src/babylonjs-viewer/save.js
+++ b/src/babylonjs-viewer/save.js
@@ -2,14 +2,15 @@ import { useBlockProps } from "@wordpress/block-editor";
 import { Fragment } from "@wordpress/element";
 
 export default function save({ attributes }) {
-	const { url } = attributes;
+	const { model } = attributes;
+	const { title, url } = model;
 
 	return (
 		<div { ...useBlockProps.save() }>
 			{(url && url !== "") &&
 				<Fragment>
 					<p>
-						{ `Loading model from "${url}"`}
+						Rendering <b>{title}</b> from <em>{url}</em>
 					</p>
 					<div className="babylonjs-viewer" model={url}></div>
 				</Fragment>

--- a/src/babylonjs-viewer/save.js
+++ b/src/babylonjs-viewer/save.js
@@ -2,24 +2,24 @@ import { useBlockProps } from "@wordpress/block-editor";
 import { Fragment } from "@wordpress/element";
 
 export default function save({ attributes }) {
-	const { model } = attributes;
-	const { title, url } = model;
+  const { model } = attributes;
+  const { title, url } = model;
 
-	return (
-		<div { ...useBlockProps.save() }>
-			{(url && url !== "") &&
-				<Fragment>
-					<p>
-						Rendering <b>{title}</b> from <em>{url}</em>
-					</p>
-					<div className="babylonjs-viewer" model={url}></div>
-				</Fragment>
-			}
-			{!url &&
-				<p>
-					{ "No URL selected" }
-				</p>
-			}
-		</div>
-	);
+  return (
+    <div { ...useBlockProps.save() }>
+      {(url && url !== "") &&
+        <Fragment>
+          <p>
+            Rendering <b>{title}</b> from <em>{url}</em>
+          </p>
+          <div className="babylonjs-viewer" model={url}></div>
+        </Fragment>
+      }
+      {!url &&
+        <p>
+          { "No URL selected" }
+        </p>
+      }
+    </div>
+  );
 }

--- a/src/babylonjs-viewer/style.scss
+++ b/src/babylonjs-viewer/style.scss
@@ -1,4 +1,4 @@
-.wp-block-create-block-babylonjs-viewer {
+.wp-block-babylonjs-viewer-babylonjs-viewer {
 	background-color: #21759b;
 	color: #fff;
 	padding: 2px;

--- a/src/babylonjs-viewer/style.scss
+++ b/src/babylonjs-viewer/style.scss
@@ -1,5 +1,5 @@
 .wp-block-babylonjs-viewer-babylonjs-viewer {
-	background-color: #21759b;
-	color: #fff;
-	padding: 2px;
+  background-color: #21759b;
+  color: #fff;
+  padding: 2px;
 }


### PR DESCRIPTION
Updated **Babylon.JS Viewer** block to allow user to select a model from the **Media Library** or from an **url**

- updated block attributes for model data
- added **Media Library** selection
- updated documentation for **How to use** section
- re-format code indents from ***tabs*** to ***spaces***