### PR TITLE
Features/add-block-preview-for-editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ https://playground.babylonjs.com/scenes/BoomBox/BoomBox.gltf
 
 Video Tutorial:
 
-https://user-images.githubusercontent.com/57893611/212997321-70a30088-a1bd-4f7f-aa6c-1f396253ea06.mov
+https://user-images.githubusercontent.com/57893611/213171974-18f0b380-10ba-4536-a991-e9de3e1dc5cb.mov
 
 
 ---

--- a/src/babylonjs-viewer/components/BlockEditView.js
+++ b/src/babylonjs-viewer/components/BlockEditView.js
@@ -1,0 +1,53 @@
+import { Component, createRef, Fragment } from "@wordpress/element";
+import PropTypes from "prop-types";
+
+import BlockView from "./BlockView";
+import initViewer from "../scripts/initViewer";
+
+class BlockEditView extends Component {
+  constructor(props) {
+    super(props);
+
+    this.childRef = createRef();
+    this.state = {
+      viewer: null,
+    };
+  }
+
+  componentDidUpdate(previousProps) {
+    const { url: oldUrl } = previousProps
+    const { url } = this.props;
+    const { viewer } = this.state;
+
+    if (this.childRef.current) {
+      if (!viewer) {
+        this.setState({
+          viewer: initViewer(this.childRef.current, url),
+        });
+      } else if (url !== oldUrl) {
+        viewer.loadModel({
+          url,
+        });
+      }
+    }
+  }
+
+  render() {
+    const { title, url } = this.props;
+
+    return (
+      <BlockView
+        ref={this.childRef}
+        title={title}
+        url={url}
+      />
+    );
+  }
+}
+
+BlockEditView.propTypes = {
+  title: PropTypes.string,
+  url: PropTypes.string,
+};
+
+export default BlockEditView;

--- a/src/babylonjs-viewer/components/BlockView.js
+++ b/src/babylonjs-viewer/components/BlockView.js
@@ -1,25 +1,23 @@
-import { Fragment } from "@wordpress/element";
+import { forwardRef, Fragment } from "@wordpress/element";
 import PropTypes from "prop-types";
 
-export function BlockView({ title, url }) {
-  return (
-    <Fragment>
-      {(url && url !== "") &&
-        <Fragment>
-          <p>
-            Rendering <b>{title}</b> from <em>{url}</em>
-          </p>
-          <div className="babylonjs-viewer" model={url}></div>
-        </Fragment>
-      }
-      {!url &&
+const BlockView = forwardRef(({ title, url }, ref) => (
+  <Fragment>
+    {(url && url !== "") &&
+      <Fragment>
         <p>
-          { "No URL selected" }
+          Rendering <b>{title}</b> from <em>{url}</em>
         </p>
-      }
-    </Fragment>
-  );
-}
+        <div ref={ref} className="babylonjs-viewer" model={url}></div>
+      </Fragment>
+    }
+    {!url &&
+      <p>
+        { "No URL selected" }
+      </p>
+    }
+  </Fragment>
+));
 
 BlockView.propTypes = {
   title: PropTypes.string,

--- a/src/babylonjs-viewer/components/BlockView.js
+++ b/src/babylonjs-viewer/components/BlockView.js
@@ -1,0 +1,29 @@
+import { Fragment } from "@wordpress/element";
+import PropTypes from "prop-types";
+
+export function BlockView({ title, url }) {
+  return (
+    <Fragment>
+      {(url && url !== "") &&
+        <Fragment>
+          <p>
+            Rendering <b>{title}</b> from <em>{url}</em>
+          </p>
+          <div className="babylonjs-viewer" model={url}></div>
+        </Fragment>
+      }
+      {!url &&
+        <p>
+          { "No URL selected" }
+        </p>
+      }
+    </Fragment>
+  );
+}
+
+BlockView.propTypes = {
+  title: PropTypes.string,
+  url: PropTypes.string,
+};
+
+export default BlockView;

--- a/src/babylonjs-viewer/edit.js
+++ b/src/babylonjs-viewer/edit.js
@@ -14,7 +14,7 @@ import { Fragment, useState } from "@wordpress/element"
 import { edit as editIcon } from '@wordpress/icons';
 
 import "./editor.scss";
-import BlockView from "./components/BlockView";
+import BlockEditView from "./components/BlockEditView";
 
 export default function edit({ attributes, setAttributes }) {
   const { model } = attributes;
@@ -95,7 +95,7 @@ export default function edit({ attributes, setAttributes }) {
           </Fragment>
         </Fragment>
       }
-      <BlockView
+      <BlockEditView
         title={title}
         url={url}
       />

--- a/src/babylonjs-viewer/edit.js
+++ b/src/babylonjs-viewer/edit.js
@@ -14,6 +14,7 @@ import { Fragment, useState } from "@wordpress/element"
 import { edit as editIcon } from '@wordpress/icons';
 
 import "./editor.scss";
+import BlockView from "./components/BlockView";
 
 export default function edit({ attributes, setAttributes }) {
   const { model } = attributes;
@@ -94,6 +95,10 @@ export default function edit({ attributes, setAttributes }) {
           </Fragment>
         </Fragment>
       }
+      <BlockView
+        title={title}
+        url={url}
+      />
     </div>
   );
 }

--- a/src/babylonjs-viewer/save.js
+++ b/src/babylonjs-viewer/save.js
@@ -1,5 +1,6 @@
 import { useBlockProps } from "@wordpress/block-editor";
-import { Fragment } from "@wordpress/element";
+
+import BlockView from "./components/BlockView";
 
 export default function save({ attributes }) {
   const { model } = attributes;
@@ -7,19 +8,10 @@ export default function save({ attributes }) {
 
   return (
     <div { ...useBlockProps.save() }>
-      {(url && url !== "") &&
-        <Fragment>
-          <p>
-            Rendering <b>{title}</b> from <em>{url}</em>
-          </p>
-          <div className="babylonjs-viewer" model={url}></div>
-        </Fragment>
-      }
-      {!url &&
-        <p>
-          { "No URL selected" }
-        </p>
-      }
+      <BlockView
+        title={title}
+        url={url}
+      />
     </div>
   );
 }

--- a/src/babylonjs-viewer/scripts/initViewer.js
+++ b/src/babylonjs-viewer/scripts/initViewer.js
@@ -1,0 +1,14 @@
+import * as BabylonViewer from "babylonjs-viewer";
+
+export default function initViewer($element, modelUrl) {
+  return new BabylonViewer.DefaultViewer($element, {
+    camera: {
+      behaviors: {
+        autoRotate: 0,
+      },
+    },
+    model: {
+      url: modelUrl,
+    },
+  });
+}

--- a/src/babylonjs-viewer/view.js
+++ b/src/babylonjs-viewer/view.js
@@ -1,23 +1,14 @@
-import * as BabylonViewer from "babylonjs-viewer";
+import initViewer from "./scripts/initViewer";
 
 addEventListener("DOMContentLoaded", () => {
   const $blockList = document.getElementsByClassName("babylonjs-viewer");
 
   Object.keys($blockList).map((index) => {
     const $block = $blockList[index];
-    const model = $block.getAttribute("model");
+    const modelUrl = $block.getAttribute("model");
     
-    if (model && "" !== model) { 
-      new BabylonViewer.DefaultViewer($block, {
-        camera: {
-          behaviors: {
-            autoRotate: 0,
-          },
-        },
-        model: {
-          url: model,
-        },
-      });
+    if (modelUrl && "" !== modelUrl) { 
+      initViewer($block, modelUrl);
     }
   });
 });


### PR DESCRIPTION
Updated editor view for **Babylon.JS Viewer** block

- added `BlockView` component to be re-used in `save.js` and `edit.js`
- added `BlockEditView` component to preview the block and allow to load and reload model inside the **Block Editor**