### PR TITLE
Features/refactor-block-prop-types

### DIFF
--- a/src/babylonjs-viewer/components/BlockView.js
+++ b/src/babylonjs-viewer/components/BlockView.js
@@ -1,8 +1,9 @@
 import { forwardRef, Fragment } from "@wordpress/element";
 import PropTypes from "prop-types";
 
-const BlockView = forwardRef(({ model, height, width }, ref) => {
+const BlockView = forwardRef(({ model, size }, ref) => {
   const { title, url } = model;
+  const { height, width } = size;
   const inlineStyle = {};
 
   if (height > 0) {
@@ -33,14 +34,16 @@ const BlockView = forwardRef(({ model, height, width }, ref) => {
 });
 
 BlockView.propTypes = {
-  height: {
-    type: PropTypes.number,
-    default: 0,
-  },
-  width: {
-    type: PropTypes.number,
-    default: 0,
-  },
+  size: PropTypes.shape({
+    height: {
+      type: PropTypes.number,
+      default: 0,
+    },
+    width: {
+      type: PropTypes.number,
+      default: 0,
+    },
+  }),
   model: PropTypes.shape({
     title: PropTypes.string.isRequired,
     url: PropTypes.string.isRequired,

--- a/src/babylonjs-viewer/components/BlockView.js
+++ b/src/babylonjs-viewer/components/BlockView.js
@@ -1,7 +1,8 @@
 import { forwardRef, Fragment } from "@wordpress/element";
 import PropTypes from "prop-types";
 
-const BlockView = forwardRef(({ title, url, height, width }, ref) => {
+const BlockView = forwardRef(({ model, height, width }, ref) => {
+  const { title, url } = model;
   const inlineStyle = {};
 
   if (height > 0) {
@@ -32,8 +33,6 @@ const BlockView = forwardRef(({ title, url, height, width }, ref) => {
 });
 
 BlockView.propTypes = {
-  title: PropTypes.string,
-  url: PropTypes.string,
   height: {
     type: PropTypes.number,
     default: 0,
@@ -42,6 +41,10 @@ BlockView.propTypes = {
     type: PropTypes.number,
     default: 0,
   },
+  model: PropTypes.shape({
+    title: PropTypes.string.isRequired,
+    url: PropTypes.string.isRequired,
+  }),
 };
 
 export default BlockView;

--- a/src/babylonjs-viewer/components/EditBlockView.js
+++ b/src/babylonjs-viewer/components/EditBlockView.js
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import BlockView from "./BlockView";
 import initViewer from "../scripts/initViewer";
 
-class BlockEditView extends Component {
+class EditBlockView extends Component {
   constructor(props) {
     super(props);
 
@@ -16,11 +16,12 @@ class BlockEditView extends Component {
 
   componentDidUpdate(previousProps) {
     const {
-      url: oldUrl,
+      model: oldModel,
       height: oldHeight,
       width: oldWidth,
     } = previousProps
-    const { url, height, width } = this.props;
+    const { model, height, width } = this.props;
+    const { url } = model;
     const { viewer } = this.state;
 
     if (this.childRef.current) {
@@ -28,7 +29,7 @@ class BlockEditView extends Component {
         this.setState({
           viewer: initViewer(this.childRef.current, url),
         });
-      } else if (url !== oldUrl) {
+      } else if (url !== oldModel.url) {
         viewer.loadModel({
           url,
         });
@@ -42,13 +43,12 @@ class BlockEditView extends Component {
   }
 
   render() {
-    const { title, url, height, width } = this.props;
+    const { model, height, width } = this.props;
 
     return (
       <BlockView
         ref={this.childRef}
-        title={title}
-        url={url}
+        model={model}
         height={height}
         width={width}
       />
@@ -56,9 +56,7 @@ class BlockEditView extends Component {
   }
 }
 
-BlockEditView.propTypes = {
-  title: PropTypes.string,
-  url: PropTypes.string,
+EditBlockView.propTypes = {
   height: {
     type: PropTypes.number,
     default: 0,
@@ -67,6 +65,10 @@ BlockEditView.propTypes = {
     type: PropTypes.number,
     default: 0,
   },
+  model: PropTypes.shape({
+    title: PropTypes.string.isRequired,
+    url: PropTypes.string.isRequired,
+  }),
 };
 
-export default BlockEditView;
+export default EditBlockView;

--- a/src/babylonjs-viewer/components/EditBlockView.js
+++ b/src/babylonjs-viewer/components/EditBlockView.js
@@ -17,10 +17,9 @@ class EditBlockView extends Component {
   componentDidUpdate(previousProps) {
     const {
       model: oldModel,
-      height: oldHeight,
-      width: oldWidth,
+      size: oldSize,
     } = previousProps
-    const { model, height, width } = this.props;
+    const { model, size } = this.props;
     const { url } = model;
     const { viewer } = this.state;
 
@@ -33,38 +32,36 @@ class EditBlockView extends Component {
         viewer.loadModel({
           url,
         });
-      } else if (
-        height !== oldHeight
-        || width !== oldWidth
-      ) {
+      } else if (size !== oldSize) {
         viewer.engine.resize();
       }
     }
   }
 
   render() {
-    const { model, height, width } = this.props;
+    const { model, size } = this.props;
 
     return (
       <BlockView
         ref={this.childRef}
         model={model}
-        height={height}
-        width={width}
+        size={size}
       />
     );
   }
 }
 
 EditBlockView.propTypes = {
-  height: {
-    type: PropTypes.number,
-    default: 0,
-  },
-  width: {
-    type: PropTypes.number,
-    default: 0,
-  },
+  size: PropTypes.shape({
+    height: {
+      type: PropTypes.number,
+      default: 0,
+    },
+    width: {
+      type: PropTypes.number,
+      default: 0,
+    },
+  }),
   model: PropTypes.shape({
     title: PropTypes.string.isRequired,
     url: PropTypes.string.isRequired,

--- a/src/babylonjs-viewer/edit.js
+++ b/src/babylonjs-viewer/edit.js
@@ -54,8 +54,7 @@ export default function edit({ attributes, setAttributes }) {
       />
       <EditBlockView
         model={model}
-        height={height}
-        width={width}
+        size={size}
       />
     </div>
   );

--- a/src/babylonjs-viewer/edit.js
+++ b/src/babylonjs-viewer/edit.js
@@ -53,8 +53,7 @@ export default function edit({ attributes, setAttributes }) {
         }}
       />
       <EditBlockView
-        title={title}
-        url={url}
+        model={model}
         height={height}
         width={width}
       />

--- a/src/babylonjs-viewer/save.js
+++ b/src/babylonjs-viewer/save.js
@@ -4,14 +4,12 @@ import BlockView from "./components/BlockView";
 
 export default function save({ attributes }) {
   const { model, size } = attributes;
-  const { title, url } = model;
   const { height, width } = size;
 
   return (
     <div { ...useBlockProps.save() }>
       <BlockView
-        title={title}
-        url={url}
+        model={model}
         height={height}
         width={width}
       />

--- a/src/babylonjs-viewer/save.js
+++ b/src/babylonjs-viewer/save.js
@@ -4,14 +4,12 @@ import BlockView from "./components/BlockView";
 
 export default function save({ attributes }) {
   const { model, size } = attributes;
-  const { height, width } = size;
 
   return (
     <div { ...useBlockProps.save() }>
       <BlockView
         model={model}
-        height={height}
-        width={width}
+        size={size}
       />
     </div>
   );


### PR DESCRIPTION
Changed block view props for **Babylon.JS Viewer** block to `model` and `size`

- replaced `title` and `url` with `model` object
- replaced `height` and `width` with `size` object