### PR TITLE
Release/0.1.4

### DIFF
--- a/src/babylonjs-viewer/block.json
+++ b/src/babylonjs-viewer/block.json
@@ -17,6 +17,13 @@
         "title": "",
         "url": ""
       }
+    },
+    "size": {
+      "type": "object",
+      "default": {
+        "height": 0,
+        "width": 0
+      }
     }
   },
   "textdomain": "babylonjs-viewer",

--- a/src/babylonjs-viewer/components/BlockEditView.js
+++ b/src/babylonjs-viewer/components/BlockEditView.js
@@ -15,8 +15,12 @@ class BlockEditView extends Component {
   }
 
   componentDidUpdate(previousProps) {
-    const { url: oldUrl } = previousProps
-    const { url } = this.props;
+    const {
+      url: oldUrl,
+      height: oldHeight,
+      width: oldWidth,
+    } = previousProps
+    const { url, height, width } = this.props;
     const { viewer } = this.state;
 
     if (this.childRef.current) {
@@ -28,18 +32,25 @@ class BlockEditView extends Component {
         viewer.loadModel({
           url,
         });
+      } else if (
+        height !== oldHeight
+        || width !== oldWidth
+      ) {
+        viewer.engine.resize();
       }
     }
   }
 
   render() {
-    const { title, url } = this.props;
+    const { title, url, height, width } = this.props;
 
     return (
       <BlockView
         ref={this.childRef}
         title={title}
         url={url}
+        height={height}
+        width={width}
       />
     );
   }
@@ -48,6 +59,14 @@ class BlockEditView extends Component {
 BlockEditView.propTypes = {
   title: PropTypes.string,
   url: PropTypes.string,
+  height: {
+    type: PropTypes.number,
+    default: 0,
+  },
+  width: {
+    type: PropTypes.number,
+    default: 0,
+  },
 };
 
 export default BlockEditView;

--- a/src/babylonjs-viewer/components/BlockView.js
+++ b/src/babylonjs-viewer/components/BlockView.js
@@ -1,8 +1,9 @@
 import { forwardRef, Fragment } from "@wordpress/element";
 import PropTypes from "prop-types";
 
-const BlockView = forwardRef(({ model, height, width }, ref) => {
+const BlockView = forwardRef(({ model, size }, ref) => {
   const { title, url } = model;
+  const { height, width } = size;
   const inlineStyle = {};
 
   if (height > 0) {
@@ -33,14 +34,16 @@ const BlockView = forwardRef(({ model, height, width }, ref) => {
 });
 
 BlockView.propTypes = {
-  height: {
-    type: PropTypes.number,
-    default: 0,
-  },
-  width: {
-    type: PropTypes.number,
-    default: 0,
-  },
+  size: PropTypes.shape({
+    height: {
+      type: PropTypes.number,
+      default: 0,
+    },
+    width: {
+      type: PropTypes.number,
+      default: 0,
+    },
+  }),
   model: PropTypes.shape({
     title: PropTypes.string.isRequired,
     url: PropTypes.string.isRequired,

--- a/src/babylonjs-viewer/components/BlockView.js
+++ b/src/babylonjs-viewer/components/BlockView.js
@@ -1,7 +1,8 @@
 import { forwardRef, Fragment } from "@wordpress/element";
 import PropTypes from "prop-types";
 
-const BlockView = forwardRef(({ title, url, height, width }, ref) => {
+const BlockView = forwardRef(({ model, height, width }, ref) => {
+  const { title, url } = model;
   const inlineStyle = {};
 
   if (height > 0) {
@@ -32,8 +33,6 @@ const BlockView = forwardRef(({ title, url, height, width }, ref) => {
 });
 
 BlockView.propTypes = {
-  title: PropTypes.string,
-  url: PropTypes.string,
   height: {
     type: PropTypes.number,
     default: 0,
@@ -42,6 +41,10 @@ BlockView.propTypes = {
     type: PropTypes.number,
     default: 0,
   },
+  model: PropTypes.shape({
+    title: PropTypes.string.isRequired,
+    url: PropTypes.string.isRequired,
+  }),
 };
 
 export default BlockView;

--- a/src/babylonjs-viewer/components/BlockView.js
+++ b/src/babylonjs-viewer/components/BlockView.js
@@ -1,27 +1,47 @@
 import { forwardRef, Fragment } from "@wordpress/element";
 import PropTypes from "prop-types";
 
-const BlockView = forwardRef(({ title, url }, ref) => (
-  <Fragment>
-    {(url && url !== "") &&
-      <Fragment>
+const BlockView = forwardRef(({ title, url, height, width }, ref) => {
+  const inlineStyle = {};
+
+  if (height > 0) {
+    inlineStyle.height = `${height}px`;
+  }
+
+  if (width > 0) {
+    inlineStyle.width = `${width}px`;
+  }
+
+  return (
+    <Fragment>
+      {(url && url !== "") &&
+        <Fragment>
+          <p>
+            Rendering <b>{title}</b> from <em>{url}</em>
+          </p>
+          <div ref={ref} className="babylonjs-viewer" model={url} style={inlineStyle}></div>
+        </Fragment>
+      }
+      {!url &&
         <p>
-          Rendering <b>{title}</b> from <em>{url}</em>
+          { "No URL selected" }
         </p>
-        <div ref={ref} className="babylonjs-viewer" model={url}></div>
-      </Fragment>
-    }
-    {!url &&
-      <p>
-        { "No URL selected" }
-      </p>
-    }
-  </Fragment>
-));
+      }
+    </Fragment>
+  );
+});
 
 BlockView.propTypes = {
   title: PropTypes.string,
   url: PropTypes.string,
+  height: {
+    type: PropTypes.number,
+    default: 0,
+  },
+  width: {
+    type: PropTypes.number,
+    default: 0,
+  },
 };
 
 export default BlockView;

--- a/src/babylonjs-viewer/components/EditBlockControls.js
+++ b/src/babylonjs-viewer/components/EditBlockControls.js
@@ -1,0 +1,97 @@
+import {
+  MediaUpload,
+  BlockControls,
+} from "@wordpress/block-editor";
+import {
+  TextControl,
+  Button,
+  ToolbarGroup,
+  ToolbarButton,
+} from "@wordpress/components";
+import { Fragment, useState } from "@wordpress/element"
+import {
+  edit as editIcon,
+} from '@wordpress/icons';
+import PropTypes from "prop-types";
+
+function EditBlockControls(props) {
+  const {
+    model,
+    onTitleChange,
+    onUrlChange,
+  } = props;
+  const { title, url } = model;
+  const [showEdit, setShowEdit] = useState(true);
+
+  return (
+    <Fragment>
+        <BlockControls>
+        <ToolbarGroup>
+          <ToolbarButton
+            icon={editIcon}
+            label="Edit"
+            isPressed={showEdit}
+            onClick={() => setShowEdit(!showEdit)}
+          />
+        </ToolbarGroup>
+      </BlockControls>
+      {showEdit &&
+        <Fragment>
+          <Fragment>
+            <p>
+              {`Enter the model metas or `}
+              <MediaUpload
+                onSelect={({ title, url }) => {
+                  onTitleChange(title);
+                  onUrlChange(url);
+                }}
+                multiple={false}
+                render={({ open }) => (
+                  <Fragment>
+                    <Button
+                      onClick={open}
+                      variant="link"
+                      style={{
+                        color: "white",
+                        padding: 0,
+                        fontSize: "inherit",
+                      }}
+                    >
+                      select from Media Library
+                    </Button>
+                  </Fragment>
+                )}
+              />
+            </p>
+          </Fragment>
+          <Fragment>
+            <TextControl
+              label="Title"
+              value={title}
+              onChange={(newValue) => onTitleChange(newValue)}
+            />
+            <TextControl
+              label="URL"
+              value={url}
+              onChange={(newValue) => onUrlChange(newValue)}
+            />
+          </Fragment>
+        </Fragment>
+      }
+    </Fragment>
+  );
+}
+
+EditBlockControls.propTypes = {
+  model: {
+    type: PropTypes.object,
+    default: {
+      title: "",
+      url: "",
+    },
+  },
+  onTitleChange: PropTypes.func,
+  onUrlChange: PropTypes.func,
+};
+
+export default EditBlockControls;

--- a/src/babylonjs-viewer/components/EditBlockView.js
+++ b/src/babylonjs-viewer/components/EditBlockView.js
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import BlockView from "./BlockView";
 import initViewer from "../scripts/initViewer";
 
-class BlockEditView extends Component {
+class EditBlockView extends Component {
   constructor(props) {
     super(props);
 
@@ -16,11 +16,12 @@ class BlockEditView extends Component {
 
   componentDidUpdate(previousProps) {
     const {
-      url: oldUrl,
+      model: oldModel,
       height: oldHeight,
       width: oldWidth,
     } = previousProps
-    const { url, height, width } = this.props;
+    const { model, height, width } = this.props;
+    const { url } = model;
     const { viewer } = this.state;
 
     if (this.childRef.current) {
@@ -28,7 +29,7 @@ class BlockEditView extends Component {
         this.setState({
           viewer: initViewer(this.childRef.current, url),
         });
-      } else if (url !== oldUrl) {
+      } else if (url !== oldModel.url) {
         viewer.loadModel({
           url,
         });
@@ -42,13 +43,12 @@ class BlockEditView extends Component {
   }
 
   render() {
-    const { title, url, height, width } = this.props;
+    const { model, height, width } = this.props;
 
     return (
       <BlockView
         ref={this.childRef}
-        title={title}
-        url={url}
+        model={model}
         height={height}
         width={width}
       />
@@ -56,9 +56,7 @@ class BlockEditView extends Component {
   }
 }
 
-BlockEditView.propTypes = {
-  title: PropTypes.string,
-  url: PropTypes.string,
+EditBlockView.propTypes = {
   height: {
     type: PropTypes.number,
     default: 0,
@@ -67,6 +65,10 @@ BlockEditView.propTypes = {
     type: PropTypes.number,
     default: 0,
   },
+  model: PropTypes.shape({
+    title: PropTypes.string.isRequired,
+    url: PropTypes.string.isRequired,
+  }),
 };
 
-export default BlockEditView;
+export default EditBlockView;

--- a/src/babylonjs-viewer/components/EditBlockView.js
+++ b/src/babylonjs-viewer/components/EditBlockView.js
@@ -17,10 +17,9 @@ class EditBlockView extends Component {
   componentDidUpdate(previousProps) {
     const {
       model: oldModel,
-      height: oldHeight,
-      width: oldWidth,
+      size: oldSize,
     } = previousProps
-    const { model, height, width } = this.props;
+    const { model, size } = this.props;
     const { url } = model;
     const { viewer } = this.state;
 
@@ -33,38 +32,36 @@ class EditBlockView extends Component {
         viewer.loadModel({
           url,
         });
-      } else if (
-        height !== oldHeight
-        || width !== oldWidth
-      ) {
+      } else if (size !== oldSize) {
         viewer.engine.resize();
       }
     }
   }
 
   render() {
-    const { model, height, width } = this.props;
+    const { model, size } = this.props;
 
     return (
       <BlockView
         ref={this.childRef}
         model={model}
-        height={height}
-        width={width}
+        size={size}
       />
     );
   }
 }
 
 EditBlockView.propTypes = {
-  height: {
-    type: PropTypes.number,
-    default: 0,
-  },
-  width: {
-    type: PropTypes.number,
-    default: 0,
-  },
+  size: PropTypes.shape({
+    height: {
+      type: PropTypes.number,
+      default: 0,
+    },
+    width: {
+      type: PropTypes.number,
+      default: 0,
+    },
+  }),
   model: PropTypes.shape({
     title: PropTypes.string.isRequired,
     url: PropTypes.string.isRequired,

--- a/src/babylonjs-viewer/components/EditBlockView.js
+++ b/src/babylonjs-viewer/components/EditBlockView.js
@@ -1,4 +1,4 @@
-import { Component, createRef, Fragment } from "@wordpress/element";
+import { Component, createRef } from "@wordpress/element";
 import PropTypes from "prop-types";
 
 import BlockView from "./BlockView";

--- a/src/babylonjs-viewer/components/EditInspectorControls.js
+++ b/src/babylonjs-viewer/components/EditInspectorControls.js
@@ -1,0 +1,42 @@
+import { InspectorControls } from "@wordpress/block-editor";
+import {
+  TextControl,
+  Panel,
+  PanelBody,
+  PanelRow,
+} from "@wordpress/components";
+
+export default function EditInspectorControls(props) {
+  const {
+    height,
+    width,
+    onHeightChange,
+    onWidthChange,
+  } = props
+  return (
+    <InspectorControls key="setting">
+      <Panel header="Viewer Settings">
+        <PanelBody title="Dimensions" initialOpen={true}>
+          <PanelRow>
+            <TextControl
+              label="Height"
+              type="number"
+              value={height}
+              onChange={(newValue) => onHeightChange(newValue)}
+            />
+            PX
+          </PanelRow>
+          <PanelRow>
+            <TextControl
+              label="Width"
+              type="number"
+              value={width}
+              onChange={(newValue) => onWidthChange(newValue)}
+            />
+            PX
+          </PanelRow>
+        </PanelBody>
+      </Panel>
+    </InspectorControls>
+  );
+}

--- a/src/babylonjs-viewer/components/EditInspectorControls.js
+++ b/src/babylonjs-viewer/components/EditInspectorControls.js
@@ -5,14 +5,16 @@ import {
   PanelBody,
   PanelRow,
 } from "@wordpress/components";
+import PropTypes from "prop-types";
 
-export default function EditInspectorControls(props) {
+function EditInspectorControls(props) {
   const {
-    height,
-    width,
+    size,
     onHeightChange,
     onWidthChange,
   } = props
+  const { height, width } = size;
+
   return (
     <InspectorControls key="setting">
       <Panel header="Viewer Settings">
@@ -40,3 +42,17 @@ export default function EditInspectorControls(props) {
     </InspectorControls>
   );
 }
+
+EditInspectorControls.propTypes = {
+  size: {
+    type: PropTypes.object,
+    default: {
+      height: 0,
+      width: 0,
+    },
+  },
+  onHeightChange: PropTypes.func,
+  onWidthChange: PropTypes.func,
+};
+
+export default EditInspectorControls;

--- a/src/babylonjs-viewer/edit.js
+++ b/src/babylonjs-viewer/edit.js
@@ -3,16 +3,12 @@ import {
   useBlockProps,
   MediaUpload,
   BlockControls,
-  InspectorControls,
 } from "@wordpress/block-editor";
 import {
   TextControl,
   Button,
   ToolbarGroup,
   ToolbarButton,
-  Panel,
-  PanelBody,
-  PanelRow,
 } from "@wordpress/components";
 import { Fragment, useState } from "@wordpress/element"
 import {
@@ -21,6 +17,7 @@ import {
 
 import "./editor.scss";
 import BlockEditView from "./components/BlockEditView";
+import EditInspectorControls from "./components/EditInspectorControls";
 
 export default function edit({ attributes, setAttributes }) {
   const { model, size } = attributes;
@@ -102,44 +99,26 @@ export default function edit({ attributes, setAttributes }) {
           </Fragment>
         </Fragment>
       }
-      <InspectorControls key="setting">
-        <Panel header="Viewer Settings">
-          <PanelBody title="Dimensions" initialOpen={true}>
-            <PanelRow>
-              <TextControl
-                label="Height"
-                type="number"
-                value={height}
-                onChange={(newValue) => {
-                  setAttributes({
-                    size: {
-                      height: newValue,
-                      width,
-                    },
-                  });
-                }}
-              />
-              PX
-            </PanelRow>
-            <PanelRow>
-              <TextControl
-                label="Width"
-                type="number"
-                value={width}
-                onChange={(newValue) => {
-                  setAttributes({
-                    size: {
-                      height,
-                      width: newValue,
-                    },
-                  });
-                }}
-              />
-              PX
-            </PanelRow>
-          </PanelBody>
-        </Panel>
-      </InspectorControls>
+      <EditInspectorControls
+        height={height}
+        width={width}
+        onHeightChange={(newValue) => {
+          setAttributes({
+            size: {
+              height: newValue,
+              width,
+            },
+          });
+        }}
+        onWidthChange={(newValue) => {
+          setAttributes({
+            size: {
+              height,
+              width: newValue,
+            },
+          });
+        }}
+      />
       <BlockEditView
         title={title}
         url={url}

--- a/src/babylonjs-viewer/edit.js
+++ b/src/babylonjs-viewer/edit.js
@@ -3,22 +3,29 @@ import {
   useBlockProps,
   MediaUpload,
   BlockControls,
+  InspectorControls,
 } from "@wordpress/block-editor";
 import {
   TextControl,
   Button,
   ToolbarGroup,
   ToolbarButton,
+  Panel,
+  PanelBody,
+  PanelRow,
 } from "@wordpress/components";
 import { Fragment, useState } from "@wordpress/element"
-import { edit as editIcon } from '@wordpress/icons';
+import {
+  edit as editIcon,
+} from '@wordpress/icons';
 
 import "./editor.scss";
 import BlockEditView from "./components/BlockEditView";
 
 export default function edit({ attributes, setAttributes }) {
-  const { model } = attributes;
+  const { model, size } = attributes;
   const { title, url } = model;
+  const { height, width } = size;
 
   const [showEdit, setShowEdit] = useState(true);
 
@@ -95,9 +102,49 @@ export default function edit({ attributes, setAttributes }) {
           </Fragment>
         </Fragment>
       }
+      <InspectorControls key="setting">
+        <Panel header="Viewer Settings">
+          <PanelBody title="Dimensions" initialOpen={true}>
+            <PanelRow>
+              <TextControl
+                label="Height"
+                type="number"
+                value={height}
+                onChange={(newValue) => {
+                  setAttributes({
+                    size: {
+                      height: newValue,
+                      width,
+                    },
+                  });
+                }}
+              />
+              PX
+            </PanelRow>
+            <PanelRow>
+              <TextControl
+                label="Width"
+                type="number"
+                value={width}
+                onChange={(newValue) => {
+                  setAttributes({
+                    size: {
+                      height,
+                      width: newValue,
+                    },
+                  });
+                }}
+              />
+              PX
+            </PanelRow>
+          </PanelBody>
+        </Panel>
+      </InspectorControls>
       <BlockEditView
         title={title}
         url={url}
+        height={height}
+        width={width}
       />
     </div>
   );

--- a/src/babylonjs-viewer/edit.js
+++ b/src/babylonjs-viewer/edit.js
@@ -54,8 +54,7 @@ export default function edit({ attributes, setAttributes }) {
       />
       <EditBlockView
         model={model}
-        height={height}
-        width={width}
+        size={size}
       />
     </div>
   );

--- a/src/babylonjs-viewer/edit.js
+++ b/src/babylonjs-viewer/edit.js
@@ -53,8 +53,7 @@ export default function edit({ attributes, setAttributes }) {
         }}
       />
       <EditBlockView
-        title={title}
-        url={url}
+        model={model}
         height={height}
         width={width}
       />

--- a/src/babylonjs-viewer/edit.js
+++ b/src/babylonjs-viewer/edit.js
@@ -100,8 +100,7 @@ export default function edit({ attributes, setAttributes }) {
         </Fragment>
       }
       <EditInspectorControls
-        height={height}
-        width={width}
+        size={size}
         onHeightChange={(newValue) => {
           setAttributes({
             size: {

--- a/src/babylonjs-viewer/edit.js
+++ b/src/babylonjs-viewer/edit.js
@@ -3,7 +3,7 @@ import { useBlockProps } from "@wordpress/block-editor";
 
 import "./editor.scss";
 
-import BlockEditView from "./components/BlockEditView";
+import EditBlockView from "./components/EditBlockView";
 import EditInspectorControls from "./components/EditInspectorControls";
 import EditBlockControls from "./components/EditBlockControls";
 
@@ -52,7 +52,7 @@ export default function edit({ attributes, setAttributes }) {
           });
         }}
       />
-      <BlockEditView
+      <EditBlockView
         title={title}
         url={url}
         height={height}

--- a/src/babylonjs-viewer/edit.js
+++ b/src/babylonjs-viewer/edit.js
@@ -1,104 +1,38 @@
 import { __ } from "@wordpress/i18n";
-import {
-  useBlockProps,
-  MediaUpload,
-  BlockControls,
-} from "@wordpress/block-editor";
-import {
-  TextControl,
-  Button,
-  ToolbarGroup,
-  ToolbarButton,
-} from "@wordpress/components";
-import { Fragment, useState } from "@wordpress/element"
-import {
-  edit as editIcon,
-} from '@wordpress/icons';
+import { useBlockProps } from "@wordpress/block-editor";
 
 import "./editor.scss";
+
 import BlockEditView from "./components/BlockEditView";
 import EditInspectorControls from "./components/EditInspectorControls";
+import EditBlockControls from "./components/EditBlockControls";
 
 export default function edit({ attributes, setAttributes }) {
   const { model, size } = attributes;
   const { title, url } = model;
   const { height, width } = size;
 
-  const [showEdit, setShowEdit] = useState(true);
-
   return (
     <div {...useBlockProps()}>
-      <BlockControls>
-        <ToolbarGroup>
-          <ToolbarButton
-            icon={editIcon}
-            label="Edit"
-            isPressed={showEdit}
-            onClick={() => setShowEdit(!showEdit)}
-          />
-        </ToolbarGroup>
-      </BlockControls>
-      {showEdit &&
-        <Fragment>
-          <Fragment>
-            <p>
-              {`Enter the model metas or `}
-              <MediaUpload
-                onSelect={({ title, url }) => {
-                  setAttributes({
-                    model: {
-                      title: title,
-                      url: url,
-                    },
-                  });
-                }}
-                multiple={false}
-                render={({ open }) => (
-                  <Fragment>
-                    <Button
-                      onClick={open}
-                      variant="link"
-                      style={{
-                        color: "white",
-                        padding: 0,
-                        fontSize: "inherit",
-                      }}
-                    >
-                      select from Media Library
-                    </Button>
-                  </Fragment>
-                )}
-              />
-            </p>
-          </Fragment>
-          <Fragment>
-            <TextControl
-              label="Title"
-              value={title}
-              onChange={(newValue) => {
-                setAttributes({
-                  model: {
-                    title: newValue,
-                    url: url,
-                  },
-                });
-              }}
-            />
-            <TextControl
-              label="URL"
-              value={url}
-              onChange={(newValue) => {
-                setAttributes({
-                  model: {
-                    title: title,
-                    url: newValue,
-                  }
-                });
-              }}
-            />
-          </Fragment>
-        </Fragment>
-      }
+      <EditBlockControls
+        model={model}
+        onTitleChange={(newValue) => {
+          setAttributes({
+            model: {
+              title: newValue,
+              url,
+            },
+          });
+        }}
+        onUrlChange={(newValue) => {
+          setAttributes({
+            model: {
+              title,
+              url: newValue,
+            },
+          });
+        }}
+      />
       <EditInspectorControls
         size={size}
         onHeightChange={(newValue) => {

--- a/src/babylonjs-viewer/save.js
+++ b/src/babylonjs-viewer/save.js
@@ -4,14 +4,12 @@ import BlockView from "./components/BlockView";
 
 export default function save({ attributes }) {
   const { model, size } = attributes;
-  const { title, url } = model;
   const { height, width } = size;
 
   return (
     <div { ...useBlockProps.save() }>
       <BlockView
-        title={title}
-        url={url}
+        model={model}
         height={height}
         width={width}
       />

--- a/src/babylonjs-viewer/save.js
+++ b/src/babylonjs-viewer/save.js
@@ -3,14 +3,17 @@ import { useBlockProps } from "@wordpress/block-editor";
 import BlockView from "./components/BlockView";
 
 export default function save({ attributes }) {
-  const { model } = attributes;
+  const { model, size } = attributes;
   const { title, url } = model;
+  const { height, width } = size;
 
   return (
     <div { ...useBlockProps.save() }>
       <BlockView
         title={title}
         url={url}
+        height={height}
+        width={width}
       />
     </div>
   );

--- a/src/babylonjs-viewer/save.js
+++ b/src/babylonjs-viewer/save.js
@@ -4,14 +4,12 @@ import BlockView from "./components/BlockView";
 
 export default function save({ attributes }) {
   const { model, size } = attributes;
-  const { height, width } = size;
 
   return (
     <div { ...useBlockProps.save() }>
       <BlockView
         model={model}
-        height={height}
-        width={width}
+        size={size}
       />
     </div>
   );


### PR DESCRIPTION
# 0.1.4

Added `size` attribute to resize the viewer in **Babylon.JS Viewer** block

- added `size` attribute with required input fields
- extracted components from `edit.js` for readability
- updated `title` and `url` props to `model` in `BlockView` compnonents