### PR TITLE
fix/height-overriden-on-frontend

### DIFF
--- a/src/babylonjs-viewer/components/BlockView.js
+++ b/src/babylonjs-viewer/components/BlockView.js
@@ -21,7 +21,9 @@ const BlockView = forwardRef(({ model, size }, ref) => {
           <p>
             Rendering <b>{title}</b> from <em>{url}</em>
           </p>
-          <div ref={ref} className="babylonjs-viewer" model={url} style={inlineStyle}></div>
+          <div ref={ref} className="babylonjs-viewer" model={url} style={inlineStyle}>
+            <div className="babylonjs-viewer__container"></div>
+          </div>
         </Fragment>
       }
       {!url &&

--- a/src/babylonjs-viewer/scripts/initViewer.js
+++ b/src/babylonjs-viewer/scripts/initViewer.js
@@ -1,7 +1,9 @@
 import * as BabylonViewer from "babylonjs-viewer";
 
 export default function initViewer($element, modelUrl) {
-  return new BabylonViewer.DefaultViewer($element, {
+  const viewerContainer = $element.querySelector(".babylonjs-viewer__container");
+
+  return new BabylonViewer.DefaultViewer(viewerContainer, {
     camera: {
       behaviors: {
         autoRotate: 0,


### PR DESCRIPTION
Fixed issue with custom height for **Babylon.JS Viewer** block not working on frontend

See [Babylon.js Viewer documentation](https://doc.babylonjs.com/features/featuresDeepDive/babylonViewer)