### PR TITLE
Release/0.1.5

### DIFF
--- a/src/babylonjs-viewer/components/BlockView.js
+++ b/src/babylonjs-viewer/components/BlockView.js
@@ -21,7 +21,9 @@ const BlockView = forwardRef(({ model, size }, ref) => {
           <p>
             Rendering <b>{title}</b> from <em>{url}</em>
           </p>
-          <div ref={ref} className="babylonjs-viewer" model={url} style={inlineStyle}></div>
+          <div ref={ref} className="babylonjs-viewer" model={url} style={inlineStyle}>
+            <div className="babylonjs-viewer__container"></div>
+          </div>
         </Fragment>
       }
       {!url &&

--- a/src/babylonjs-viewer/components/EditBlockControls.js
+++ b/src/babylonjs-viewer/components/EditBlockControls.js
@@ -52,7 +52,7 @@ function EditBlockControls(props) {
                       onClick={open}
                       variant="link"
                       style={{
-                        color: "white",
+                        color: "inherit",
                         padding: 0,
                         fontSize: "inherit",
                       }}

--- a/src/babylonjs-viewer/editor.scss
+++ b/src/babylonjs-viewer/editor.scss
@@ -1,3 +1,1 @@
-.wp-block-babylonjs-viewer-babylonjs-viewer {
-  border: 1px dotted #f00;
-}
+.wp-block-babylonjs-viewer-babylonjs-viewer {}

--- a/src/babylonjs-viewer/scripts/initViewer.js
+++ b/src/babylonjs-viewer/scripts/initViewer.js
@@ -1,7 +1,9 @@
 import * as BabylonViewer from "babylonjs-viewer";
 
 export default function initViewer($element, modelUrl) {
-  return new BabylonViewer.DefaultViewer($element, {
+  const viewerContainer = $element.querySelector(".babylonjs-viewer__container");
+
+  return new BabylonViewer.DefaultViewer(viewerContainer, {
     camera: {
       behaviors: {
         autoRotate: 0,

--- a/src/babylonjs-viewer/style.scss
+++ b/src/babylonjs-viewer/style.scss
@@ -1,5 +1,1 @@
-.wp-block-babylonjs-viewer-babylonjs-viewer {
-  background-color: #21759b;
-  color: #fff;
-  padding: 2px;
-}
+.wp-block-babylonjs-viewer-babylonjs-viewer {}


### PR DESCRIPTION
# 0.1.5

- fixed custom `height` not working on frontend for **Babylon.JS Viewer**
- removed initial block style in editor and frontend for **Babylon.JS Viewer**